### PR TITLE
fix Conan component reference typo

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -161,5 +161,5 @@ class Xrpl(ConanFile):
             'openssl::crypto',
             'date::date',
             'grpc::grpc++',
-            'xxHash::xxhash',
+            'xxhash::xxhash',
         ]


### PR DESCRIPTION
typo in component name prevents downstream usage of libxrpl

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ximinez/rippled/3)
<!-- Reviewable:end -->
